### PR TITLE
Update typing files to match Deno import syntax

### DIFF
--- a/lib/deps/tarn@3.0.0/dist/PendingOperation.d.ts
+++ b/lib/deps/tarn@3.0.0/dist/PendingOperation.d.ts
@@ -1,4 +1,4 @@
-import { Deferred } from './utils';
+import { Deferred } from './utils.d.ts';
 export declare class PendingOperation<T> {
     protected timeoutMillis: number;
     possibleTimeoutCause: Error | null;

--- a/lib/deps/tarn@3.0.0/dist/Pool.d.ts
+++ b/lib/deps/tarn@3.0.0/dist/Pool.d.ts
@@ -54,7 +54,7 @@ export declare class Pool<T> {
      * Reaping cycle.
      */
     check(): void;
-    destroy(): Promise<import("./PromiseInspection").PromiseInspection<unknown> | import("./PromiseInspection").PromiseInspection<void>>;
+    destroy(): Promise<import("./PromiseInspection.d.ts").PromiseInspection<unknown> | import("./PromiseInspection.d.ts").PromiseInspection<void>>;
     on(eventName: 'acquireRequest', handler: (eventId: number) => void): void;
     on(eventName: 'acquireSuccess', handler: (eventId: number, resource: T) => void): void;
     on(eventName: 'acquireFail', handler: (eventId: number, err: Error) => void): void;

--- a/lib/deps/tarn@3.0.0/dist/Pool.d.ts
+++ b/lib/deps/tarn@3.0.0/dist/Pool.d.ts
@@ -1,7 +1,7 @@
-/// <reference types="node" />
-import { PendingOperation } from './PendingOperation';
-import { Resource } from './Resource';
-import { EventEmitter } from 'events';
+import type { PendingOperation } from './PendingOperation.d.ts';
+import type { Resource } from './Resource.d.ts';
+import type { EventEmitter } from "https://deno.land/std@0.147.0/node/events.ts";
+
 export interface PoolOptions<T> {
     create: CallbackOrPromise<T>;
     destroy: (resource: T) => any;

--- a/lib/deps/tarn@3.0.0/dist/Resource.d.ts
+++ b/lib/deps/tarn@3.0.0/dist/Resource.d.ts
@@ -1,4 +1,4 @@
-import { Deferred } from './utils';
+import { Deferred } from './utils.d.ts';
 export declare class Resource<T> {
     resource: T;
     readonly timestamp: number;

--- a/lib/deps/tarn@3.0.0/dist/utils.d.ts
+++ b/lib/deps/tarn@3.0.0/dist/utils.d.ts
@@ -1,4 +1,4 @@
-import { PromiseInspection } from './PromiseInspection';
+import { PromiseInspection } from './PromiseInspection.d.ts';
 export interface Deferred<T> {
     resolve: (val: T) => any;
     reject: <T>(err: T) => any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@
 
 import type { PassThrough, Duplex } from "https://deno.land/std@0.147.0/node/stream.ts";
 import type { EventEmitter } from "https://deno.land/std@0.147.0/node/events.ts";
-import type { Pool } from "https://deno.land/x/dex@1.0.2/lib/deps/tarn@3.0.0/dist/Pool.d.ts";
+import type { Pool } from "../lib/deps/tarn@3.0.0/dist/Pool.d.ts";
 import * as ResultTypes from './result.d.ts';
 
 import { ConnectionOptions } from "tls";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,8 +11,6 @@ import type { EventEmitter } from "https://deno.land/std@0.147.0/node/events.ts"
 import type { Pool } from "../lib/deps/tarn@3.0.0/dist/Pool.d.ts";
 import * as ResultTypes from './result.d.ts';
 
-import { ConnectionOptions } from "tls";
-
 // # Generic type-level utilities
 
 // If T is object then make it a partial otherwise fallback to any
@@ -1840,7 +1838,7 @@ declare namespace Knex {
     statement_timeout?: false | number;
     connectionTimeoutMillis?: number;
     keepAliveInitialDelayMillis?: number;
-    ssl?: boolean | ConnectionOptions;
+    ssl?: boolean | unknown;
   }
 
   type RedshiftConnectionConfig = PgConnectionConfig;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,9 +9,10 @@
 /// <reference types="node" />
 
 import tarn = require('tarn');
-import events = require('events');
 import stream = require('stream');
-import ResultTypes = require('./result.d.ts');
+
+import type { EventEmitter } from "https://deno.land/std@0.147.0/node/events.ts";
+import * as ResultTypes from './result.d.ts';
 
 import { ConnectionOptions } from "tls";
 
@@ -324,7 +325,7 @@ interface PgTableOptions {
 }
 
 interface Knex<TRecord extends {} = any, TResult = unknown[]>
-  extends Knex.QueryInterface<TRecord, TResult>, events.EventEmitter {
+  extends Knex.QueryInterface<TRecord, TResult>, EventEmitter {
   <TRecord2 = TRecord, TResult2 = DeferredKeySelection<TRecord2, never>[]>(
     tableName?: Knex.TableDescriptor | Knex.AliasDict,
     options?: TableOptions
@@ -1368,7 +1369,7 @@ declare namespace Knex {
   // Raw
 
   interface Raw<TResult = any>
-    extends events.EventEmitter,
+    extends EventEmitter,
       ChainableInterface<ResolveResult<TResult>> {
     wrap<TResult2 = TResult>(before: string, after: string): Raw<TResult>;
     toSQL(): Sql;
@@ -1972,7 +1973,7 @@ declare namespace Knex {
   // Clients
   //
 
-  class Client extends events.EventEmitter {
+  class Client extends EventEmitter {
     constructor(config: Config);
     config: Config;
     dialect: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@
 import tarn = require('tarn');
 import events = require('events');
 import stream = require('stream');
-import ResultTypes = require('./result');
+import ResultTypes = require('./result.d.ts');
 
 import { ConnectionOptions } from "tls";
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,12 +6,9 @@
 //                 Shrey Jain <https://github.com/shreyjain1994>
 // TypeScript Version: 3.7
 
-/// <reference types="node" />
-
-import tarn = require('tarn');
-import stream = require('stream');
-
+import type { PassThrough, Duplex } from "https://deno.land/std@0.147.0/node/stream.ts";
 import type { EventEmitter } from "https://deno.land/std@0.147.0/node/events.ts";
+import type { Pool } from "https://deno.land/x/dex@1.0.2/lib/deps/tarn@3.0.0/dist/Pool.d.ts";
 import * as ResultTypes from './result.d.ts';
 
 import { ConnectionOptions } from "tls";
@@ -1472,16 +1469,16 @@ declare namespace Knex {
     connection(connection: any): this;
     debug(enabled: boolean): this;
     transacting(trx: Transaction): this;
-    stream(handler: (readable: stream.PassThrough) => any): Promise<any>;
+    stream(handler: (readable: PassThrough) => any): Promise<any>;
     stream(
       options: Readonly<{ [key: string]: any }>,
-      handler: (readable: stream.PassThrough) => any
+      handler: (readable: PassThrough) => any
     ): Promise<any>;
-    stream(options?: Readonly<{ [key: string]: any }>): stream.PassThrough;
+    stream(options?: Readonly<{ [key: string]: any }>): PassThrough;
     pipe<T extends NodeJS.WritableStream>(
       writable: T,
       options?: Readonly<{ [key: string]: any }>
-    ): stream.PassThrough;
+    ): PassThrough;
     asCallback(callback: Function): Promise<T>;
   }
 
@@ -1839,7 +1836,7 @@ declare namespace Knex {
     host?: string;
     connectionString?: string;
     keepAlive?: boolean;
-    stream?: stream.Duplex;
+    stream?: Duplex;
     statement_timeout?: false | number;
     connectionTimeoutMillis?: number;
     keepAliveInitialDelayMillis?: number;


### PR DESCRIPTION
This is required to appropriately support type imports.

When not applying this change, you'll have an error like the following:

```bash
$ deno task test   
Warning deno task is unstable and may drastically change in the future
Task test deno test -A --coverage=coverage services/settings plugins/inventory
Download https://deno.land/x/dex@1.0.2/types/result
error: Module not found "https://deno.land/x/dex@1.0.2/types/result".
    at https://deno.land/x/dex@1.0.2/types/index.d.ts:14:30
```