### PR TITLE
Use "node:*" dependencies instead of jspm-core

### DIFF
--- a/lib-dyn/deps.ts
+++ b/lib-dyn/deps.ts
@@ -4,16 +4,16 @@ export const tarn = dex_tarn;
 import dex_inherits from "https://dev.jspm.io/inherits@2.0";
 export const inherits = dex_inherits;
 
-import dex_events from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/events.js";
+import dex_events from "node:events";
 export const events = dex_events;
 
-import dex_util from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/util.js";
+import dex_util from "node:util";
 export const util = dex_util;
 
 import dex_lodash from "https://dev.jspm.io/lodash@4";
 export const _ = dex_lodash;
 
-import dex_debug from "https://dev.jspm.io/debug@4.1.1";
+import dex_debug from "https://dev.jspm.io/debug@4";
 export const debug = dex_debug;
 
 import * as dex_colors from "https://deno.land/std/fmt/colors.ts";
@@ -25,14 +25,14 @@ export const uuid = dex_uuid;
 import * as dex_path from "https://deno.land/std/path/mod.ts";
 export const path = dex_path;
 
-import dex_assert from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/assert.js";
+import dex_assert from "node:assert";
 export const assert = dex_assert;
 
-import dex_url from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/url.js";
+import dex_url from "node:url";
 export const url = dex_url;
 
-import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.2.0";
+import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.5.0";
 export const pgconn = dex_pgconn;
 
-import dex_stream from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/stream.js";
+import dex_stream from "node:stream";
 export const stream = dex_stream;


### PR DESCRIPTION
Just like #3, this PR updates the `lib-dyn/deps.ts`, but instead of using `std/node` it uses `node:*`, since these have been merged into deno core as of 0.178.0.